### PR TITLE
Remove redundant deps pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.9"
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
     - uses: pre-commit/action@v3.0.0
 
   tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,3 @@ repos:
       additional_dependencies:
       - "types-PyYAML"
       - "types-requests"
-      - "pyfirecrest~=1.4.0"
-      - "aiida-core~=2.4.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-    python: python3.9
-
 ci:
     autoupdate_schedule: monthly
     autofix_prs: true

--- a/aiida_firecrest/remote_path.py
+++ b/aiida_firecrest/remote_path.py
@@ -16,7 +16,7 @@ import stat
 import tempfile
 from typing import Callable, TypeVar
 
-from firecrest import ClientCredentialsAuth, Firecrest  # type: ignore[attr-defined]
+from firecrest import ClientCredentialsAuth, Firecrest
 
 from .utils import convert_header_exceptions
 
@@ -256,7 +256,7 @@ class FcPath(os.PathLike[str]):
         """Return the SHA256 (256-bit) checksum of the file."""
         # this is not part of the pathlib.Path API, but is useful
         with convert_header_exceptions({"machine": self._machine, "path": self}):
-            return self._client.checksum(self._machine, self.path)
+            return self._client.checksum(self._machine, self.path)  # type: ignore [no-any-return]
 
     # methods that utilise stat calls
 

--- a/aiida_firecrest/scheduler.py
+++ b/aiida_firecrest/scheduler.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
     from aiida_firecrest.transport import FirecrestTransport
 
 
-class FirecrestScheduler(Scheduler):
+class FirecrestScheduler(Scheduler):  # type: ignore[misc]
     """Scheduler interface for FirecREST."""
 
     transport: FirecrestTransport
     _job_resource_class = SlurmJobResource
-    _features: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+    _features: ClassVar[dict[str, Any]] = {
         "can_query_by_user": False,
     }
     _logger = Scheduler._logger.getChild("firecrest")
@@ -223,7 +223,7 @@ class FirecrestScheduler(Scheduler):
             if user is not None and raw_result["user"] != user:
                 continue
 
-            this_job = JobInfo()  # type: ignore
+            this_job = JobInfo()
 
             this_job.job_id = raw_result["jobid"]
             this_job.annotation = ""

--- a/aiida_firecrest/transport.py
+++ b/aiida_firecrest/transport.py
@@ -16,7 +16,7 @@ from aiida.transports import Transport
 from aiida.transports.transport import validate_positive_number
 from aiida.transports.util import FileAttribute
 from click.types import ParamType
-from firecrest import ClientCredentialsAuth, Firecrest  # type: ignore[attr-defined]
+from firecrest import ClientCredentialsAuth, Firecrest
 
 from .remote_path import FcPath, convert_header_exceptions  # type: ignore[attr-defined]
 
@@ -32,7 +32,7 @@ class ValidAuthOption(TypedDict, total=False):
     callback: Callable[..., Any]  # for validation
 
 
-class FirecrestTransport(Transport):
+class FirecrestTransport(Transport):  # type: ignore[misc]
     """Transport interface for FirecREST."""
 
     # override these options, because they don't really make sense for a REST-API,
@@ -44,10 +44,10 @@ class FirecrestTransport(Transport):
     #   across all transport instances
     # TODO upstream issue
     # TODO also open an issue that the `verdi computer test won't work with a REST-API`
-    _common_auth_options: ClassVar[list[Any]] = []  # type: ignore[misc]
+    _common_auth_options: ClassVar[list[Any]] = []
     _DEFAULT_SAFE_OPEN_INTERVAL = 0.0
 
-    _valid_auth_options: ClassVar[list[tuple[str, ValidAuthOption]]] = [  # type: ignore[misc]
+    _valid_auth_options: ClassVar[list[tuple[str, ValidAuthOption]]] = [
         (
             "url",
             {
@@ -148,7 +148,7 @@ class FirecrestTransport(Transport):
         # there is no overhead for "opening" a connection to a REST-API,
         # but still allow the user to set a safe interval if they really want to
         kwargs.setdefault("safe_interval", 0)
-        super().__init__(**kwargs)  # type: ignore
+        super().__init__(**kwargs)
 
         assert isinstance(url, str), "url must be a string"
         assert isinstance(token_uri, str), "token_uri must be a string"
@@ -231,7 +231,7 @@ class FirecrestTransport(Transport):
 
     def get_attribute(self, path: str) -> FileAttribute:
         result = self._cwd.joinpath(path).stat()
-        return FileAttribute(  # type: ignore
+        return FileAttribute(
             {
                 "st_size": result.st_size,
                 "st_uid": result.st_uid,


### PR DESCRIPTION
Having two places for dependencies create unnecessary redundancy. Better to have everything in the pyproject.toml0 and using this in the CI

I think pinning the python version in the pre-commit file is much of use, but more annoying than helpful, better would pinning package dependency versions.