### PR TITLE
`scheduler`: better and more tests

### DIFF
--- a/.firecrest-demo-config.json
+++ b/.firecrest-demo-config.json
@@ -7,5 +7,7 @@
     "temp_directory": "",
     "small_file_size_mb": 5.0,
     "workdir": "",
-    "api_version": "1.16.0"
+    "api_version": "1.16.0",
+    "builder_metadata_options_account": ""
+
 }

--- a/.firecrest-demo-config.json
+++ b/.firecrest-demo-config.json
@@ -8,6 +8,5 @@
     "small_file_size_mb": 5.0,
     "workdir": "",
     "api_version": "1.16.0",
-    "builder_metadata_options_account": ""
-
+    "builder_metadata_options_custom_scheduler_commands": []
 }

--- a/aiida_firecrest/scheduler.py
+++ b/aiida_firecrest/scheduler.py
@@ -221,14 +221,17 @@ class FirecrestScheduler(Scheduler):
             try:
                 for page_iter in itertools.count():
                     results += transport._client.poll_active(
-                        transport._machine, jobs, page_number=page_iter
+                        transport._machine,
+                        jobs,
+                        page_number=page_iter,
+                        page_size=self._DEFAULT_PAGE_SIZE,
                     )
                     if len(results) < self._DEFAULT_PAGE_SIZE * (page_iter + 1):
                         break
             except FirecrestException as exc:
-                # firecrest returns error if the job is completed
                 # TODO: check what type of error is returned and handle it properly
-                if "Invalid job id specified" not in str(exc):
+                if "Invalid job id" not in str(exc):
+                    # firecrest returns error if the job is completed, while aiida expect a silent return
                     raise SchedulerError(str(exc)) from exc
         job_list = []
         for raw_result in results:

--- a/aiida_firecrest/transport.py
+++ b/aiida_firecrest/transport.py
@@ -454,8 +454,6 @@ class FirecrestTransport(Transport):
 
     def chdir(self, path: str) -> None:
         """Change the current working directory."""
-        # with open('/home/khosra_a/check_me', 'a') as f:
-        #     f.write(f"chdir: {path}, {type(path)}\n")
         new_path = self._cwd.joinpath(path)
         if not new_path.is_dir():
             raise OSError(f"'{new_path}' is not a valid directory")

--- a/aiida_firecrest/transport.py
+++ b/aiida_firecrest/transport.py
@@ -401,6 +401,8 @@ class FirecrestTransport(Transport):
         # aiida-core/src/aiida/orm/utils/remote:clean_remote()
         self._is_open = True
 
+        self.checksum_check = False
+
     def __str__(self) -> str:
         """Return the name of the plugin."""
         return self.__class__.__name__
@@ -452,6 +454,8 @@ class FirecrestTransport(Transport):
 
     def chdir(self, path: str) -> None:
         """Change the current working directory."""
+        # with open('/home/khosra_a/check_me', 'a') as f:
+        #     f.write(f"chdir: {path}, {type(path)}\n")
         new_path = self._cwd.joinpath(path)
         if not new_path.is_dir():
             raise OSError(f"'{new_path}' is not a valid directory")
@@ -723,7 +727,8 @@ class FirecrestTransport(Transport):
                 down_obj = self._client.external_download(self._machine, str(remote))
                 down_obj.finish_download(local)
 
-        self._validate_checksum(local, remote)
+        if self.checksum_check:
+            self._validate_checksum(local, remote)
 
     def _validate_checksum(
         self, localpath: str | Path, remotepath: str | FcPath
@@ -965,7 +970,8 @@ class FirecrestTransport(Transport):
                 )
                 up_obj.finish_upload()
 
-        self._validate_checksum(localpath, str(remote))
+        if self.checksum_check:
+            self._validate_checksum(localpath, str(remote))
 
     def payoff(self, path: str | FcPath | Path) -> bool:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,19 +392,20 @@ class MockClientCredentialsAuth:
 class ComputerFirecrestConfig:
     """Configuration of a computer using FirecREST as transport plugin.
 
-    Args:
-
-        url: The URL of the FirecREST server.
-        token_uri: The URI to receive  tokens.
-        client_id: The client ID for the client credentials.
-        client_secret: The client secret for the client credentials.
-        compute_resource: The name of the compute resource. This is the name of the machine.
-        temp_directory: A temporary directory on the machine for transient zip files.
-        workdir: The aiida working directory on the machine.
-        api_version: The version of the FirecREST API.
-        builder_metadata_options_custom_scheduler_commands: a list of custom scheduler commands when submitting a job,
-          for example ["#SBATCH --account=mr32", "#SBATCH --constraint=mc", "#SBATCH --mem=10K"].
-        small_file_size_mb: The maximum file size for direct upload & download."""
+    :param url: The URL of the FirecREST server.
+    :param token_uri: The URI to receive  tokens.
+    :param client_id: The client ID for the client credentials.
+    :param client_secret: The client secret for the client credentials.
+    :param compute_resource: The name of the compute resource. This is the name of the machine.
+    :param temp_directory: A temporary directory on the machine for transient zip files.
+    :param workdir: The aiida working directory on the machine.
+    :param api_version: The version of the FirecREST API.
+    :param builder_metadata_options_custom_scheduler_commands: A list of custom
+           scheduler commands when submitting a job, for example
+           ["#SBATCH --account=mr32",
+            "#SBATCH --constraint=mc",
+            "#SBATCH --mem=10K"].
+    :param small_file_size_mb: The maximum file size for direct upload & download."""
 
     url: str
     token_uri: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import itertools
 import json
@@ -390,7 +390,21 @@ class MockClientCredentialsAuth:
 
 @dataclass
 class ComputerFirecrestConfig:
-    """Configuration of a computer using FirecREST as transport plugin."""
+    """Configuration of a computer using FirecREST as transport plugin.
+
+    Args:
+
+        url: The URL of the FirecREST server.
+        token_uri: The URI to receive  tokens.
+        client_id: The client ID for the client credentials.
+        client_secret: The client secret for the client credentials.
+        compute_resource: The name of the compute resource. This is the name of the machine.
+        temp_directory: A temporary directory on the machine for transient zip files.
+        workdir: The aiida working directory on the machine.
+        api_version: The version of the FirecREST API.
+        builder_metadata_options_custom_scheduler_commands: a list of custom scheduler commands when submitting a job,
+          for example ["#SBATCH --account=mr32", "#SBATCH --constraint=mc", "#SBATCH --mem=10K"].
+        small_file_size_mb: The maximum file size for direct upload & download."""
 
     url: str
     token_uri: str
@@ -400,8 +414,10 @@ class ComputerFirecrestConfig:
     temp_directory: str
     workdir: str
     api_version: str
-    builder_metadata_options_account: str
     small_file_size_mb: float = 1.0
+    builder_metadata_options_custom_scheduler_commands: list[str] = field(
+        default_factory=list
+    )
 
 
 class RequestTelemetry:
@@ -532,5 +548,5 @@ def firecrest_config(
             small_file_size_mb=1.0,
             temp_directory=str(_temp_directory),
             api_version="2",
-            builder_metadata_options_account="",
+            builder_metadata_options_custom_scheduler_commands=[],
         )

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -36,10 +36,10 @@ def test_calculation_basic(firecrest_computer: orm.Computer, firecrest_config):
     builder = code.get_builder()
     builder.x = orm.Int(1)
     builder.y = orm.Int(2)
-    builder.metadata.options.account = firecrest_config.builder_metadata_options_account
-    builder.metadata.options.custom_scheduler_commands = (
-        "#SBATCH --constraint=mc\n#SBATCH --mem=10K"
+    custom_scheduler_commands = "\n".join(
+        firecrest_config.builder_metadata_options_custom_scheduler_commands
     )
+    builder.metadata.options.custom_scheduler_commands = custom_scheduler_commands
 
     _, node = engine.run_get_node(builder)
     assert node.is_finished_ok

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -20,8 +20,9 @@ def _no_retries():
     manage.get_config().set_option(MAX_ATTEMPTS_OPTION, max_attempts)
 
 
+@pytest.mark.timeout(180)
 @pytest.mark.usefixtures("aiida_profile_clean", "no_retries")
-def test_calculation_basic(firecrest_computer: orm.Computer):
+def test_calculation_basic(firecrest_computer: orm.Computer, firecrest_config):
     """Test running a simple `arithmetic.add` calculation."""
     code = orm.InstalledCode(
         label="test_code",
@@ -35,6 +36,10 @@ def test_calculation_basic(firecrest_computer: orm.Computer):
     builder = code.get_builder()
     builder.x = orm.Int(1)
     builder.y = orm.Int(2)
+    builder.metadata.options.account = firecrest_config.builder_metadata_options_account
+    builder.metadata.options.custom_scheduler_commands = (
+        "#SBATCH --constraint=mc\n#SBATCH --mem=10K"
+    )
 
     _, node = engine.run_get_node(builder)
     assert node.is_finished_ok

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,46 +1,114 @@
 from pathlib import Path
+import textwrap
+from time import sleep
 
 from aiida import orm
+from aiida.schedulers import SchedulerError
 from aiida.schedulers.datastructures import CodeRunMode, JobTemplate
 import pytest
 
 from aiida_firecrest.scheduler import FirecrestScheduler
-from conftest import Values
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
-def test_submit_job(firecrest_computer: orm.Computer, tmp_path: Path):
+def test_submit_job(firecrest_computer: orm.Computer, firecrest_config, tmpdir: Path):
+    """Test submitting a job to the scheduler.
+    Note: this test relies on a functional transport.put() method."""
+
     transport = firecrest_computer.get_transport()
     scheduler = FirecrestScheduler()
     scheduler.set_transport(transport)
 
-    with pytest.raises(FileNotFoundError):
-        scheduler.submit_job(transport.getcwd(), "unknown.sh")
+    # raise error if file not found
+    with pytest.raises(SchedulerError):
+        scheduler.submit_job(firecrest_config.workdir, "unknown.sh")
 
-    _script = Path(tmp_path / "job.sh")
-    _script.write_text("#!/bin/bash\n\necho 'hello world'")
+    shell_script = f"""
+    #!/bin/bash
+    #SBATCH --no-requeue
+    #SBATCH --job-name="aiida-1929"
+    #SBATCH --get-user-env
+    #SBATCH --output=_scheduler-stdout.txt
+    #SBATCH --error=_scheduler-stderr.txt
+    #SBATCH --account={firecrest_config.builder_metadata_options_account}
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=1
+    #SBATCH --constraint=mc
+    #SBATCH --mem=10K
 
-    job_id = scheduler.submit_job(transport.getcwd(), _script)
-    # this is how aiida expects the job_id to be returned
+    echo 'hello world'
+    """
+
+    dedented_script = textwrap.dedent(shell_script).strip()
+    Path(tmpdir / "job.sh").write_text(dedented_script)
+    remote_ = transport._cwd.joinpath(firecrest_config.workdir, "job.sh")
+    transport.put(tmpdir / "job.sh", remote_)
+
+    job_id = scheduler.submit_job(firecrest_config.workdir, "job.sh")
+
     assert isinstance(job_id, str)
 
 
+@pytest.mark.timeout(180)
 @pytest.mark.usefixtures("aiida_profile_clean")
-def test_get_jobs(firecrest_computer: orm.Computer):
+def test_get_and_kill_jobs(
+    firecrest_computer: orm.Computer, firecrest_config, tmpdir: Path
+):
+    """Test getting and killing jobs from the scheduler.
+    We test the two together for performance reasons, as this test might run against
+      a real server and we don't want to leave parasitic jobs behind.
+      also less billing for the user.
+    Note: this test relies on a functional transport.put() method.
+    """
     transport = firecrest_computer.get_transport()
     scheduler = FirecrestScheduler()
     scheduler.set_transport(transport)
 
-    # test pagaination
-    scheduler._DEFAULT_PAGE_SIZE = 2
-    Values._DEFAULT_PAGE_SIZE = 2
+    # don't raise in case of invalid job id
+    scheduler.get_jobs(["000"])
 
-    joblist = ["111", "222", "333", "444", "555"]
+    shell_script = f"""
+    #!/bin/bash
+    #SBATCH --no-requeue
+    #SBATCH --job-name="aiida-1929"
+    #SBATCH --get-user-env
+    #SBATCH --output=_scheduler-stdout.txt
+    #SBATCH --error=_scheduler-stderr.txt
+    #SBATCH --account={firecrest_config.builder_metadata_options_account}
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=1
+    #SBATCH --constraint=mc
+    #SBATCH --mem=10K
+
+    sleep 180
+    """
+
+    joblist = []
+    dedented_script = textwrap.dedent(shell_script).strip()
+    Path(tmpdir / "job.sh").write_text(dedented_script)
+    remote_ = transport._cwd.joinpath(firecrest_config.workdir, "job.sh")
+    transport.put(tmpdir / "job.sh", remote_)
+
+    for _ in range(5):
+        joblist.append(scheduler.submit_job(firecrest_config.workdir, "job.sh"))
+
+    # test pagaination is working
+    scheduler._DEFAULT_PAGE_SIZE = 2
     result = scheduler.get_jobs(joblist)
     assert len(result) == 5
     for i in range(5):
-        assert result[i].job_id == str(joblist[i])
+        assert result[i].job_id in joblist
         # TODO: one could check states as well
+
+    # test kill jobs
+    for jobid in joblist:
+        scheduler.kill_job(jobid)
+
+    # sometimes it takes time for the server to respond
+    sleep(5)
+
+    result = scheduler.get_jobs(joblist)
+    assert not len(result)
 
 
 def test_write_script_full():
@@ -68,9 +136,9 @@ def test_write_script_full():
     #SBATCH --mem=1
     test_command
     """
-    expectaion_flat = "\n".join(line.strip() for line in expectaion.splitlines()).strip(
-        "\n"
-    )
+    expectation_flat = "\n".join(
+        line.strip() for line in expectaion.splitlines()
+    ).strip("\n")
     scheduler = FirecrestScheduler()
     template = JobTemplate(
         {
@@ -98,7 +166,7 @@ def test_write_script_full():
         }
     )
     try:
-        assert scheduler.get_submit_script(template).rstrip() == expectaion_flat
+        assert scheduler.get_submit_script(template).rstrip() == expectation_flat
     except AssertionError:
         print(scheduler.get_submit_script(template).rstrip())
         print(expectaion)
@@ -116,9 +184,9 @@ def test_write_script_minimal():
     #SBATCH --ntasks-per-node=1
     """
 
-    expectaion_flat = "\n".join(line.strip() for line in expectaion.splitlines()).strip(
-        "\n"
-    )
+    expectation_flat = "\n".join(
+        line.strip() for line in expectaion.splitlines()
+    ).strip("\n")
     scheduler = FirecrestScheduler()
     template = JobTemplate(
         {
@@ -131,7 +199,7 @@ def test_write_script_minimal():
     )
 
     try:
-        assert scheduler.get_submit_script(template).rstrip() == expectaion_flat
+        assert scheduler.get_submit_script(template).rstrip() == expectation_flat
     except AssertionError:
         print(scheduler.get_submit_script(template).rstrip())
         print(expectaion)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -150,6 +150,27 @@ def test_putfile_getfile(firecrest_computer: orm.Computer, tmpdir: Path):
     assert not Path(_local_download / "remote_link").is_symlink()
     assert Path(_local_download / "remote_link").read_text() == "file1"
 
+    # test the self.checksum_check
+    with patch.object(
+        transport, "_validate_checksum", autospec=True
+    ) as mock_validate_checksum:
+        transport.checksum_check = True
+        transport.putfile(_local / "file1", _remote / "file1_checksum")
+        transport.getfile(
+            _remote / "file1_checksum", _local_download / "file1_checksum"
+        )
+    assert mock_validate_checksum.call_count == 2
+
+    with patch.object(
+        transport, "_validate_checksum", autospec=True
+    ) as mock_validate_checksum:
+        transport.checksum_check = False
+        transport.putfile(_local / "file1", _remote / "file1_checksum2")
+        transport.getfile(
+            _remote / "file1_checksum2", _local_download / "file1_checksum2"
+        )
+    assert mock_validate_checksum.call_count == 0
+
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_remove(firecrest_computer: orm.Computer, tmpdir: Path):


### PR DESCRIPTION
Changes include:

- `tests/conftest.py`
  - `MockFirecrest`
    - keep track of submitted jobs through `Slurm.all_jobs`
    - implemented `cancel()` for killing jobs
    - in `poll_active` when `job_id` is not found, raise `FirecrestException`  just like firecrest does. --this includes when the job is finished.
  - removed redundant `conftest.Values`

- `tests/test_calculation.py::test_calculation_basic`
  - support for account number which is useful for tests against real server


- `tests/test_scheduler.py`
  - added tests for `transport.kill_jobs`
  - overall improvement in the logic. Now, all `test_scheduler.py` tests pass against server
