### PR TITLE
`_dynamic_info_firecrest_version` updated with new development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ exclude = [
 
 [tool.ruff]
 line-length = 120
-extend-select = ["A", "B", "C4", "ICN", "ISC", "N", "RUF", "SIM"]
+lint.extend-select = ["A", "B", "C4", "ICN", "ISC", "N", "RUF", "SIM"]
 # extend-ignore = []
 
 [tool.isort]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,6 +324,20 @@ class MockFirecrest:
                     "value": "Slurm",
                 }
             ],
+            "general": [
+                {
+                    "description": "FirecREST version.",
+                    "name": "FIRECREST_VERSION",
+                    "unit": "",
+                    "value": "v1.16.1-dev.9",
+                },
+                {
+                    "description": "FirecREST build timestamp.",
+                    "name": "FIRECREST_BUILD",
+                    "unit": "",
+                    "value": "2024-08-16T15:58:47Z",
+                },
+            ],
             "storage": [
                 {
                     "description": "Type of object storage, like `swift`, `s3v2` or `s3v4`.",
@@ -361,17 +375,13 @@ class MockFirecrest:
             ],
             "utilities": [
                 {
-                    "description": "The maximum allowable file size for various operations"
-                    " of the utilities microservice",
+                    "description": "The maximum allowable file size for various operations of the utilities microservice.",
                     "name": "UTILITIES_MAX_FILE_SIZE",
                     "unit": "MB",
                     "value": "5",
                 },
                 {
-                    "description": (
-                        "Maximum time duration for executing the commands "
-                        "in the cluster for the utilities microservice."
-                    ),
+                    "description": "Maximum time duration for executing the commands in the cluster for the utilities microservice.",
                     "name": "UTILITIES_TIMEOUT",
                     "unit": "seconds",
                     "value": "5",

--- a/tests/test_computer.py
+++ b/tests/test_computer.py
@@ -163,14 +163,12 @@ def test_dynamic_info_firecrest_version(
     assert result == "10.10.10"
 
     # raise BadParameter if the version is not supported
-    with pytest.raises(BadParameter) as exc_info:
-        result = _dynamic_info_firecrest_version(ctx, None, "0.0.0")
-    assert "FirecREST api version 0.0.0 is not supported" in str(exc_info.value)
+    with pytest.raises(BadParameter, match=r".*FirecREST api version 0.0.0 is not supported.*")):
+       _dynamic_info_firecrest_version(ctx, None, "0.0.0")
 
     # raise BadParameter if the input is nonsense, latest, stable, etc.
-    with pytest.raises(BadParameter) as exc_info:
-        result = _dynamic_info_firecrest_version(ctx, None, "latest")
-    assert "Invalid input" in str(exc_info.value)
+    with pytest.raises(BadParameter, match=r".*Invalid input.*"):
+        _dynamic_info_firecrest_version(ctx, None, "latest")
 
     # in case could not get the version from the server, should abort, as it is a required parameter.
     with patch.object(MockFirecrest, "parameters", autospec=True) as mock_parameters:

--- a/tests/test_computer.py
+++ b/tests/test_computer.py
@@ -163,8 +163,10 @@ def test_dynamic_info_firecrest_version(
     assert result == "10.10.10"
 
     # raise BadParameter if the version is not supported
-    with pytest.raises(BadParameter, match=r".*FirecREST api version 0.0.0 is not supported.*"):
-       _dynamic_info_firecrest_version(ctx, None, "0.0.0")
+    with pytest.raises(
+        BadParameter, match=r".*FirecREST api version 0.0.0 is not supported.*"
+    ):
+        _dynamic_info_firecrest_version(ctx, None, "0.0.0")
 
     # raise BadParameter if the input is nonsense, latest, stable, etc.
     with pytest.raises(BadParameter, match=r".*Invalid input.*"):

--- a/tests/test_computer.py
+++ b/tests/test_computer.py
@@ -107,9 +107,10 @@ def test_validate_temp_directory(
     ).exists()
 
 
-def test_dynamic_info(firecrest_config, monkeypatch, tmpdir: Path):
+def test_dynamic_info_direct_size(firecrest_config, monkeypatch, tmpdir: Path):
     from aiida_firecrest.transport import _dynamic_info_direct_size
 
+    assert monkeypatch is not None
     monkeypatch.setattr("click.echo", lambda x: None)
     ctx = Mock()
     ctx.params = {
@@ -130,3 +131,28 @@ def test_dynamic_info(firecrest_config, monkeypatch, tmpdir: Path):
     # note: user cannot enter negative numbers anyways, click raise as this shoule be float not str
     result = _dynamic_info_direct_size(ctx, None, 10)
     assert result == 10
+
+
+def test_dynamic_info_firecrest_version(firecrest_config, monkeypatch, tmpdir: Path):
+
+    from aiida_firecrest.transport import _dynamic_info_firecrest_version
+
+    monkeypatch.setattr("click.echo", lambda x: None)
+    ctx = Mock()
+    ctx.params = {
+        "url": f"{firecrest_config.url}",
+        "token_uri": f"{firecrest_config.token_uri}",
+        "client_id": f"{firecrest_config.client_id}",
+        "client_secret": f"{firecrest_config.client_secret}",
+        "compute_resource": f"{firecrest_config.compute_resource}",
+        "temp_directory": f"{firecrest_config.temp_directory}",
+        "api_version": f"{firecrest_config.api_version}",
+    }
+
+    # should catch FIRECREST_VERSION if value is not provided
+    result = _dynamic_info_firecrest_version(ctx, None, "0")
+    assert isinstance(result, str)
+
+    # should use the value if provided
+    result = _dynamic_info_firecrest_version(ctx, None, "10.10.10")
+    assert result == "10.10.10"

--- a/tests/test_computer.py
+++ b/tests/test_computer.py
@@ -163,7 +163,7 @@ def test_dynamic_info_firecrest_version(
     assert result == "10.10.10"
 
     # raise BadParameter if the version is not supported
-    with pytest.raises(BadParameter, match=r".*FirecREST api version 0.0.0 is not supported.*")):
+    with pytest.raises(BadParameter, match=r".*FirecREST api version 0.0.0 is not supported.*"):
        _dynamic_info_firecrest_version(ctx, None, "0.0.0")
 
     # raise BadParameter if the input is nonsense, latest, stable, etc.


### PR DESCRIPTION
`/status/parameters` endpoint of firecrest api  is now updated with version value.
We fetch this way and drop the previous work around that was implemented.
Fixes:
https://github.com/aiidateam/aiida-firecrest/issues/43