### PR TITLE
More helpful message in case when credentials are wrong.

### DIFF
--- a/aiida_firecrest/transport.py
+++ b/aiida_firecrest/transport.py
@@ -408,11 +408,16 @@ class FirecrestTransport(AsyncTransport):
             _version = self.blocking_client.server_version()
         except Exception as e:
             raise RuntimeError(
-                "Could not get the version of the FirecREST server"
+                "Could not get the version of the FirecREST server.\nPerhaps you have inserted wrong credentials?"
             ) from e
 
+        if _version is None:
+            raise RuntimeError(
+                "Could not get the version of the FirecREST server, it returned None.\nPerhaps you have inserted wrong credentials?"
+            )
+
         try:
-            parsed_version = parse(_version)  # type: ignore
+            parsed_version = parse(_version)
         except InvalidVersion as err:
             raise ValueError(
                 f"Cannot parse the retrieved version from the server: {_version}"

--- a/tests/test_computer.py
+++ b/tests/test_computer.py
@@ -164,11 +164,20 @@ def test_dynamic_info_firecrest_version(
 
     transport.blocking_client.server_version = _mocked
     with pytest.raises(
-        RuntimeError, match="Could not get the version of the FirecREST server"
+        RuntimeError,
+        match="Could not get the version of the FirecREST server.\nPerhaps you have inserted wrong credentials?",
     ):
         transport._get_firecrest_version()
 
-    # raise ValueError if the version is invalid
+    # raise RuntimeError if the version is None
+    transport.blocking_client.server_version = lambda: None
+    with pytest.raises(
+        RuntimeError,
+        match="Could not get the version of the FirecREST server, it returned None.\nPerhaps you have inserted wrong credentials?",
+    ):
+        transport._get_firecrest_version()
+
+    # raise ValueError if the version is invalid or not parsable
     transport.blocking_client.server_version = lambda: "invalid_version"
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Fixes #105 

This could happen when `aiida-firecrest` is configured via non interactive modes, for e.g.