### PR TITLE
docs: add "How to cite" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ pre-commit run --all-files
 
 ---
 
-### Acknowledgment:
+## How to cite
+
+If you use `aiida-firecrest` in your research, we would be grateful if you could cite the following publication:
+
+* E. Palme *et al.*, *FirecREST v2: lessons learned from redesigning an API for scalable HPC resource access*, [arXiv:2512.11634](https://doi.org/10.48550/arXiv.2512.11634) (2025)
+
+---
+
+## Acknowledgment:
 
 This project is supported by SwissTwins project.
 


### PR DESCRIPTION
Adds a `How to cite` section to the README, just before the acknowledgment, pointing to the FirecREST v2 paper:

> E. Palme *et al.*, *FirecREST v2: lessons learned from redesigning an API for scalable HPC resource access*, [arXiv:2512.11634](https://doi.org/10.48550/arXiv.2512.11634) (2025)

The citation follows the style used in [`aiida-core`](https://github.com/aiidateam/aiida-core#how-to-cite) (italic authors/title, DOI link), with the `arXiv:2512.11634` part linking to https://doi.org/10.48550/arXiv.2512.11634.

The acknowledgment heading was promoted from `###` to `##` so it doesn't render as a subsection of `How to cite`.
